### PR TITLE
Add MC address as host

### DIFF
--- a/basehub/values.yaml.j2
+++ b/basehub/values.yaml.j2
@@ -35,6 +35,9 @@ jupyterhub:
             {%- if not LOCAL %}
             hosts:
                 - {{ 'staging-demo' if STAGING else 'demo' }}.aiidalab.io
+                {%- if not STAGING %}
+                - aiidalab-demo.materialscloud.io
+                {%- endif %}
             letsencrypt:
                 contactEmail: aiidalab@materialscloud.org
             {%- endif %}


### PR DESCRIPTION
This PR adds the new MC address (aiidalab-demo.materialscloud.io) as a host for production deployments.